### PR TITLE
chore: codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # CODEOWNERS
 
-* @opentdf/nifi @opentdf/architecture
+* @opentdf/opentdf-nifi @opentdf/architecture
 
 ## High Security Area
 


### PR DESCRIPTION
fix opentdf team name in CODEOWNERS