### PR TITLE
chore: add assertions

### DIFF
--- a/nifi-tdf-controller-services-api/pom.xml
+++ b/nifi-tdf-controller-services-api/pom.xml
@@ -20,5 +20,15 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-utils</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-ssl-context-service-api</artifactId>
+            <version>${nifi.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-key-service-api</artifactId>
+            <version>${nifi.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-tdf-nar/pom.xml
+++ b/nifi-tdf-nar/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>nifi-tdf-processors</artifactId>
+            <artifactId>nifi-tdf-controller-services-nar</artifactId>
             <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:nifi:current} -->
             <type>nar</type>
         </dependency>

--- a/nifi-tdf-nar/pom.xml
+++ b/nifi-tdf-nar/pom.xml
@@ -21,9 +21,9 @@
             <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:nifi:current} -->
         </dependency>
         <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-ssl-context-service-nar</artifactId>
-            <version>${nifi.version}</version>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>nifi-tdf-processors</artifactId>
+            <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:nifi:current} -->
             <type>nar</type>
         </dependency>
     </dependencies>

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
@@ -19,7 +19,7 @@ import org.apache.nifi.processor.util.StandardValidators;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.stream.io.StreamUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-
+import io.opentdf.platform.sdk.Config.AssertionConfig;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -104,6 +104,10 @@ public abstract class AbstractTDFProcessor extends AbstractProcessor {
             sdk = sdkBuilder.build();
         }
         return this.sdk;
+    }
+
+    AssertionConfig getAssertionConfig(ProcessContext processContext) {
+        return new AssertionConfig();
     }
 
     //this is really here to allow for easier mocking for testing

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
@@ -74,6 +74,14 @@ public abstract class AbstractTDFProcessor extends AbstractProcessor {
         return propertyValue.isExpressionLanguagePresent() ? propertyValue.evaluateAttributeExpressions() : propertyValue;
     }
 
+    Optional<PropertyValue> getPropertyValue(PropertyDescriptor propertyDescriptor, ProcessContext processContext) {
+        PropertyValue propertyValue = null;
+        if(processContext.getProperty(propertyDescriptor).isSet()){
+            propertyValue = getPropertyValue(processContext.getProperty(propertyDescriptor));
+        }
+        return Optional.ofNullable(propertyValue);
+    }
+
     private SDK sdk;
 
     /**
@@ -104,10 +112,6 @@ public abstract class AbstractTDFProcessor extends AbstractProcessor {
             sdk = sdkBuilder.build();
         }
         return this.sdk;
-    }
-
-    AssertionConfig getAssertionConfig(ProcessContext processContext) {
-        return new AssertionConfig();
     }
 
     //this is really here to allow for easier mocking for testing

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractToProcessor.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractToProcessor.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractToProcessor extends AbstractTDFProcessor{
     static final String KAS_URL_ATTRIBUTE = "kas_url";
     static final String TDF_ATTRIBUTE = "tdf_attribute";
+    static final String TDF_ASSERTION_PREFIX = "tdf_assertion_";
 
     public static final PropertyDescriptor KAS_URL = new org.apache.nifi.components.PropertyDescriptor.Builder()
             .name("KAS URL")

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -1,23 +1,31 @@
 package io.opentdf.nifi;
 
+import com.nimbusds.jose.jwk.RSAKey;
 import io.opentdf.platform.sdk.Config;
 import io.opentdf.platform.sdk.SDK;
 import io.opentdf.platform.sdk.TDF;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
+import org.apache.commons.io.FileUtils;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 
+
+import java.io.File;
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 
 @CapabilityDescription("Decrypts ZTDF flow file content")
@@ -30,13 +38,15 @@ public class ConvertFromZTDF extends AbstractTDFProcessor {
             .required(false)
             .defaultValue("false")
             .allowableValues("true", "false")
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
     public static final PropertyDescriptor ASSERTION_PUBLIC_KEY = new org.apache.nifi.components.PropertyDescriptor.Builder()
             .name("Assertion Verification Key")
-            .description("path to the public key for verifying assertions")
+            .description("path to the public key for verifying assertions - assumes X509 Public Key in PEM format")
             .required(true)
             .dependsOn(VERIFY_ASSERTIONS, new AllowableValue("true"))
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
 
@@ -48,10 +58,26 @@ public class ConvertFromZTDF extends AbstractTDFProcessor {
         return Collections.unmodifiableList(propertyDescriptors);
     }
 
+    private Config.AssertionConfig buildAssertionConfig(ProcessContext processContext) throws ProcessException{
+        try {
+            Config.AssertionConfig assertionConfig = new Config.AssertionConfig();
+            Optional<PropertyValue> verifyAssertionValue = getPropertyValue(VERIFY_ASSERTIONS, processContext);
+            if (verifyAssertionValue.isPresent() && verifyAssertionValue.get().asBoolean()) {
+                String verificationKeyPath = processContext.getProperty(ASSERTION_PUBLIC_KEY).getValue();
+                assertionConfig.keyType = Config.AssertionConfig.KeyType.RS256;
+                String pem = FileUtils.readFileToString(new File(verificationKeyPath), Charset.defaultCharset());
+                assertionConfig.rs256PublicKeyForVerifying = RSAKey.parseFromPEMEncodedX509Cert(pem).toRSAKey();
+            }
+            return assertionConfig;
+        }catch (Exception e){
+            throw new ProcessException(e);
+        }
+    }
+
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);
-        Config.AssertionConfig assertionConfig = getAssertionConfig(processContext);
+        Config.AssertionConfig assertionConfig = buildAssertionConfig(processContext);
         for (FlowFile flowFile : flowFiles) {
             try {
                 try (SeekableByteChannel seekableByteChannel = new SeekableInMemoryByteChannel(readEntireFlowFile(flowFile, processSession))) {

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -1,21 +1,18 @@
 package io.opentdf.nifi;
 
+import io.opentdf.platform.sdk.Config;
 import io.opentdf.platform.sdk.SDK;
 import io.opentdf.platform.sdk.TDF;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.stream.io.StreamUtils;
 
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 
@@ -26,12 +23,13 @@ public class ConvertFromZTDF extends AbstractTDFProcessor {
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);
+        Config.AssertionConfig assertionConfig = getAssertionConfig(processContext);
         for (FlowFile flowFile : flowFiles) {
             try {
                 try (SeekableByteChannel seekableByteChannel = new SeekableInMemoryByteChannel(readEntireFlowFile(flowFile, processSession))) {
                     FlowFile updatedFlowFile = processSession.write(flowFile, outputStream -> {
                         try {
-                            TDF.Reader reader = getTDF().loadTDF(seekableByteChannel, sdk.getServices().kas());
+                            TDF.Reader reader = getTDF().loadTDF(seekableByteChannel, assertionConfig, sdk.getServices().kas());
                             reader.readPayload(outputStream);
                         } catch (Exception e) {
                             getLogger().error("error decrypting ZTDF", e);

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -6,6 +6,8 @@ import io.opentdf.platform.sdk.TDF;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.AllowableValue;
+import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
@@ -13,12 +15,38 @@ import org.apache.nifi.processor.exception.ProcessException;
 
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
 @CapabilityDescription("Decrypts ZTDF flow file content")
 @Tags({"ZTDF", "Zero Trust Data Format", "OpenTDF", "Decrypt", "Data Centric Security"})
 public class ConvertFromZTDF extends AbstractTDFProcessor {
+
+    public static final PropertyDescriptor VERIFY_ASSERTIONS = new org.apache.nifi.components.PropertyDescriptor.Builder()
+            .name("Verify Assertions")
+            .description("Verify assertions")
+            .required(false)
+            .defaultValue("false")
+            .allowableValues("true", "false")
+            .build();
+
+    public static final PropertyDescriptor ASSERTION_PUBLIC_KEY = new org.apache.nifi.components.PropertyDescriptor.Builder()
+            .name("Assertion Verification Key")
+            .description("path to the public key for verifying assertions")
+            .required(true)
+            .dependsOn(VERIFY_ASSERTIONS, new AllowableValue("true"))
+            .build();
+
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        List<PropertyDescriptor> propertyDescriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
+        propertyDescriptors.add(VERIFY_ASSERTIONS);
+        propertyDescriptors.add(ASSERTION_PUBLIC_KEY);
+        return Collections.unmodifiableList(propertyDescriptors);
+    }
 
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -1,83 +1,30 @@
 package io.opentdf.nifi;
 
-import com.nimbusds.jose.jwk.RSAKey;
 import io.opentdf.platform.sdk.Config;
 import io.opentdf.platform.sdk.SDK;
 import io.opentdf.platform.sdk.TDF;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
-import org.apache.commons.io.FileUtils;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
-import org.apache.nifi.components.AllowableValue;
-import org.apache.nifi.components.PropertyDescriptor;
-import org.apache.nifi.components.PropertyValue;
-import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 
-
-import java.io.File;
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 
 @CapabilityDescription("Decrypts ZTDF flow file content")
 @Tags({"ZTDF", "Zero Trust Data Format", "OpenTDF", "Decrypt", "Data Centric Security"})
 public class ConvertFromZTDF extends AbstractTDFProcessor {
 
-    public static final PropertyDescriptor VERIFY_ASSERTIONS = new org.apache.nifi.components.PropertyDescriptor.Builder()
-            .name("Verify Assertions")
-            .description("Verify assertions")
-            .required(false)
-            .defaultValue("false")
-            .allowableValues("true", "false")
-            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-            .build();
-
-    public static final PropertyDescriptor ASSERTION_PUBLIC_KEY = new org.apache.nifi.components.PropertyDescriptor.Builder()
-            .name("Assertion Verification Key")
-            .description("path to the public key for verifying assertions - assumes X509 Public Key in PEM format")
-            .required(true)
-            .dependsOn(VERIFY_ASSERTIONS, new AllowableValue("true"))
-            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
-            .build();
-
-
-    @Override
-    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
-        List<PropertyDescriptor> propertyDescriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
-        propertyDescriptors.add(VERIFY_ASSERTIONS);
-        propertyDescriptors.add(ASSERTION_PUBLIC_KEY);
-        return Collections.unmodifiableList(propertyDescriptors);
-    }
-
-    private Config.AssertionConfig buildAssertionConfig(ProcessContext processContext) throws ProcessException{
-        try {
-            Config.AssertionConfig assertionConfig = new Config.AssertionConfig();
-            Optional<PropertyValue> verifyAssertionValue = getPropertyValue(VERIFY_ASSERTIONS, processContext);
-            if (verifyAssertionValue.isPresent() && verifyAssertionValue.get().asBoolean()) {
-                String verificationKeyPath = processContext.getProperty(ASSERTION_PUBLIC_KEY).getValue();
-                assertionConfig.keyType = Config.AssertionConfig.KeyType.RS256;
-                String pem = FileUtils.readFileToString(new File(verificationKeyPath), Charset.defaultCharset());
-                assertionConfig.rs256PublicKeyForVerifying = RSAKey.parseFromPEMEncodedX509Cert(pem).toRSAKey();
-            }
-            return assertionConfig;
-        }catch (Exception e){
-            throw new ProcessException(e);
-        }
-    }
 
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);
-        Config.AssertionConfig assertionConfig = buildAssertionConfig(processContext);
+        Config.AssertionConfig assertionConfig = new Config.AssertionConfig();
         for (FlowFile flowFile : flowFiles) {
             try {
                 try (SeekableByteChannel seekableByteChannel = new SeekableInMemoryByteChannel(readEntireFlowFile(flowFile, processSession))) {

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -182,6 +182,7 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 RSAPublicKey rsaPublicKey = (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
                 assertionConfig.keyType = Config.AssertionConfig.KeyType.RS256;
                 assertionConfig.rs256PrivateKeyForSigning = new RSAKey.Builder(rsaPublicKey).privateKey(rsaPrivateKey).build();
+                assertionConfig.rs256PublicKeyForVerifying = new RSAKey.Builder(rsaPublicKey).build();
             }
         }
         return assertionConfig;

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -12,18 +12,22 @@ import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
+import org.apache.nifi.expression.ExpressionLanguageScope;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.key.service.api.PrivateKeyService;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
-import org.apache.nifi.ssl.SSLContextService;
+
 
 import java.io.IOException;
 import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.*;
 import java.util.function.Consumer;
@@ -57,14 +61,16 @@ public class ConvertToZTDF extends AbstractToProcessor {
             .required(false)
             .defaultValue("false")
             .allowableValues("true", "false")
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
     public static final PropertyDescriptor PRIVATE_KEY_CONTROLLER_SERVICE = new org.apache.nifi.components.PropertyDescriptor.Builder()
             .name("Private Key Controller Service")
             .description("Optional Private Key Service; this is need for assertion signing")
             .required(true)
-            .identifiesControllerService(SSLContextService.class)
+            .identifiesControllerService(PrivateKeyService.class)
             .dependsOn(SIGN_ASSERTIONS, new AllowableValue("true"))
+            .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
 
@@ -84,6 +90,7 @@ public class ConvertToZTDF extends AbstractToProcessor {
 
     Gson gson = new Gson();
 
+
     /**
      * Build an assertion from the attribute
      * @return
@@ -93,13 +100,14 @@ public class ConvertToZTDF extends AbstractToProcessor {
         String assertionJson = flowFile.getAttribute(flowFileAttributeName);
         Map<?,?> assertionMap = gson.fromJson(assertionJson, Map.class);
         Assertion assertion = new Assertion();
-        assertion.type = assertionMap.containsKey("type") ? Assertion.Type.valueOf((String)assertionMap.get("type")).name() : null;
-        assertion.scope =assertionMap.containsKey("scope") ? Assertion.Scope.valueOf((String)assertionMap.get("scope")).name() : null;
-        assertion.appliesToState = assertionMap.containsKey("appliesToState") ? Assertion.AppliesToState.valueOf((String)assertionMap.get("appliesToState")).name() : null;
+        assertion.id = assertionMap.containsKey("id") ? (String)assertionMap.get("id") : null;
+        assertion.type = assertionMap.containsKey("type") ? (String)assertionMap.get("type") : null;
+        assertion.scope =assertionMap.containsKey("scope") ? (String)assertionMap.get("scope") : null;
+        assertion.appliesToState = assertionMap.containsKey("appliesToState") ? (String)assertionMap.get("appliesToState"): null;
         assertion.statement = new Assertion.Statement();
         Map<?,?> statementMap = (Map<?,?>)assertionMap.get("statement");
         if(statementMap!=null) {
-            assertion.statement.format = statementMap.containsKey("format") ? Assertion.StatementFormat.valueOf((String)statementMap.get("format")).name() : null;
+            assertion.statement.format = statementMap.containsKey("format") ? (String)statementMap.get("format") : null;
             assertion.statement.value = (String)statementMap.get("value");
         }
         if(assertion.scope == null){
@@ -130,29 +138,12 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 //build baseline TDF Config options
                 List<Consumer<TDFConfig>> configurationOptions = new ArrayList<>(Arrays.asList(Config.withKasInformation(kasInfoList.toArray(new Config.KASInfo[0])),
                         Config.withDataAttributes(dataAttributes.toArray(new String[0]))));
-                List<String> nifiAssertionAttributeKeys = flowFile.getAttributes().keySet().stream().filter(x->x.startsWith("tdf_assertion_")).toList();
+                List<String> nifiAssertionAttributeKeys = flowFile.getAttributes().keySet().stream().filter(x->x.startsWith(TDF_ASSERTION_PREFIX)).toList();
                 for(String nifiAssertionAttributeKey: nifiAssertionAttributeKeys) {
                     getLogger().debug(String.format("Adding assertion for NiFi attribute = %s", nifiAssertionAttributeKey));
                     configurationOptions.add(Config.WithAssertion(buildAssertion(flowFile, nifiAssertionAttributeKey)));
                 }
-                Config.AssertionConfig assertionConfig = new Config.AssertionConfig();
-                //populate assertion signing config only when sign assertions property is true and assertions exist
-                if (!nifiAssertionAttributeKeys.isEmpty() && processContext.getProperty(SIGN_ASSERTIONS).asBoolean()) {
-                    getLogger().debug("signed assertions is active");
-                    PrivateKeyService privateKeyService = getPrivateKeyService(processContext);
-                    if (privateKeyService != null) {
-                        getLogger().debug("adding signing configuration for assertion");
-                        //TODO assumes RSA256 signing key
-                        PrivateKey privateKey = privateKeyService.getPrivateKey();
-                        RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey) privateKey;
-                        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(rsaPrivateKey.getModulus(), rsaPrivateKey.getPublicExponent());
-                        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-                        RSAPublicKey rsaPublicKey = (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
-                        assertionConfig.keyType = Config.AssertionConfig.KeyType.RS256;
-                        assertionConfig.rs256PrivateKeyForSigning = new RSAKey.Builder(rsaPublicKey).privateKey(rsaPrivateKey).build();
-                    }
-                }
-                configurationOptions.add(Config.withAssertionConfig(assertionConfig));
+                configurationOptions.add(Config.withAssertionConfig(buildAssertionConfig(processContext, nifiAssertionAttributeKeys)));
                 TDFConfig config = Config.newTDFConfig(configurationOptions.toArray(new Consumer[0]));
 
                 //write ZTDF to FlowFile
@@ -172,5 +163,27 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 processSession.transfer(flowFile, REL_FAILURE);
             }
         }
+    }
+
+    private Config.AssertionConfig buildAssertionConfig(ProcessContext processContext, List<String> nifiAssertionAttributeKeys) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        Config.AssertionConfig assertionConfig = new Config.AssertionConfig();
+        Optional<PropertyValue> signAssertions = getPropertyValue(SIGN_ASSERTIONS, processContext);
+        //populate assertion signing config only when sign assertions property is true and assertions exist
+        if (!nifiAssertionAttributeKeys.isEmpty() && signAssertions.isPresent() && signAssertions.get().asBoolean()) {
+            getLogger().debug("signed assertions is active");
+            PrivateKeyService privateKeyService = getPrivateKeyService(processContext);
+            if (privateKeyService != null) {
+                getLogger().debug("adding signing configuration for assertion");
+                //TODO assumes RSA256 signing key
+                PrivateKey privateKey = privateKeyService.getPrivateKey();
+                RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey) privateKey;
+                RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(rsaPrivateKey.getModulus(), rsaPrivateKey.getPublicExponent());
+                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                RSAPublicKey rsaPublicKey = (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
+                assertionConfig.keyType = Config.AssertionConfig.KeyType.RS256;
+                assertionConfig.rs256PrivateKeyForSigning = new RSAKey.Builder(rsaPublicKey).privateKey(rsaPrivateKey).build();
+            }
+        }
+        return assertionConfig;
     }
 }

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -1,5 +1,8 @@
 package io.opentdf.nifi;
 
+import com.google.gson.Gson;
+import com.nimbusds.jose.jwk.RSAKey;
+import io.opentdf.platform.sdk.Assertion;
 import io.opentdf.platform.sdk.Config;
 import io.opentdf.platform.sdk.Config.TDFConfig;
 import io.opentdf.platform.sdk.SDK;
@@ -7,15 +10,23 @@ import org.apache.nifi.annotation.behavior.ReadsAttribute;
 import org.apache.nifi.annotation.behavior.ReadsAttributes;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.key.service.api.PrivateKeyService;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.ssl.SSLContextService;
+import org.bouncycastle.jcajce.provider.asymmetric.RSA;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.*;
+import java.util.function.Consumer;
 
 @CapabilityDescription("Transforms flow file content into a ZTDF")
 @Tags({"ZTDF", "OpenTDF", "Zero Trust Data Format", "Encrypt", "Data Centric Security"})
@@ -23,19 +34,109 @@ import java.util.stream.Collectors;
         @ReadsAttribute(attribute = "kas_url", description = "The Key Access Server (KAS) URL used TDF Creation. This overrides " +
                 "the KAS URL property of this processor."),
         @ReadsAttribute(attribute = "tdf_attribute", description = "A comma separated list of data attributes added " +
-                "to created TDF Data Policy. e.g. http://example.org/attr/foo/value/bar,http://example.org/attr/foo/value/bar2")
+                "to created TDF Data Policy. e.g. http://example.org/attr/foo/value/bar,http://example.org/attr/foo/value/bar2"),
+        @ReadsAttribute(attribute = "tdf_assertion_<id>", description = """
+                A single assertion with a JSON payload reflecting the assertion schema :
+                {\
+                "type":<>,
+                "scope":<>
+                ,\
+                "appliesToState":<>
+                "statement": {
+                 "value":<>,
+                 "format":<>,
+                }\s
+                }; more than one \
+                assertion supported through the "tdf_assertion_" attribute name prefix. e.g. tdf_assertion_1, tdf_assertion_2""")
 })
 public class ConvertToZTDF extends AbstractToProcessor {
+
+    public static final PropertyDescriptor PRIVATE_KEY_CONTEXT_SERVICE = new org.apache.nifi.components.PropertyDescriptor.Builder()
+            .name("Private Key Controller Service")
+            .description("Optional Private Key Service; this is need for assertion signing")
+            .required(false)
+            .identifiesControllerService(SSLContextService.class)
+            .build();
+
+
+    PrivateKeyService getPrivateKeyService(ProcessContext processContext) {
+        return processContext.getProperty(PRIVATE_KEY_CONTEXT_SERVICE).isSet() ?
+                processContext.getProperty(PRIVATE_KEY_CONTEXT_SERVICE)
+                        .asControllerService(PrivateKeyService.class) : null;
+    }
+
+    @Override
+    public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return Collections.unmodifiableList(Arrays.asList(SSL_CONTEXT_SERVICE, OPENTDF_CONFIG_SERVICE, FLOWFILE_PULL_SIZE, KAS_URL, PRIVATE_KEY_CONTEXT_SERVICE));
+    }
+
+    Gson gson = new Gson();
+
+    /**
+     * Build an assertion from the attribute
+     * @return
+     * @throws Exception
+     */
+    Assertion buildAssertion(FlowFile flowFile, String flowFileAttributeName) throws Exception{
+        String assertionJson = flowFile.getAttribute(flowFileAttributeName);
+        Map<?,?> assertionMap = gson.fromJson(assertionJson, Map.class);
+        Assertion assertion = new Assertion();
+        assertion.type = assertionMap.containsKey("type") ? Assertion.Type.valueOf((String)assertionMap.get("type")).name() : null;
+        assertion.scope =assertionMap.containsKey("scope") ? Assertion.Scope.valueOf((String)assertionMap.get("scope")).name() : null;
+        assertion.appliesToState = assertionMap.containsKey("appliesToState") ? Assertion.AppliesToState.valueOf((String)assertionMap.get("appliesToState")).name() : null;
+        assertion.statement = new Assertion.Statement();
+        Map<?,?> statementMap = (Map<?,?>)assertionMap.get("statement");
+        if(statementMap!=null) {
+            assertion.statement.format = statementMap.containsKey("format") ? Assertion.StatementFormat.valueOf((String)statementMap.get("format")).name() : null;
+            assertion.statement.value = (String)statementMap.get("value");
+        }
+        if(assertion.scope == null){
+            throw new Exception("assertion scope is required");
+        }
+        if(assertion.statement == null){
+            throw new Exception("assertion statement is required");
+        }
+        if(assertion.statement.format == null){
+            throw new Exception("assertion statement format is required");
+        }
+        if(assertion.appliesToState == null){
+            throw new Exception("assertion appliesToState is required");
+        }
+        if(assertion.type == null){
+            throw new Exception("assertion type is required");
+        }
+        return assertion;
+    }
 
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);
         for (final FlowFile flowFile : flowFiles) {
             try {
-                var kasInfoList = getKASInfoFromKASURLs( getKasUrl(flowFile, processContext));
+                var kasInfoList = getKASInfoFromKASURLs(getKasUrl(flowFile, processContext));
                 Set<String> dataAttributes = getDataAttributes(flowFile);
-                TDFConfig config = Config.newTDFConfig(Config.withKasInformation(kasInfoList.toArray(new Config.KASInfo[0])),
-                        Config.withDataAttributes(dataAttributes.toArray(new String[0])));
+                List<Consumer<TDFConfig>> configurationOptions = new ArrayList<>(Arrays.asList(Config.withKasInformation(kasInfoList.toArray(new Config.KASInfo[0])),
+                        Config.withDataAttributes(dataAttributes.toArray(new String[0]))));
+                List<String> nifiAssertionAttributeKeys = flowFile.getAttributes().keySet().stream().filter(x->x.startsWith("tdf_assertion_")).toList();
+                for(String nifiAssertionAttributeKey: nifiAssertionAttributeKeys) {
+                    getLogger().debug(String.format("Adding assertion for NiFi attribute = %s", nifiAssertionAttributeKey));
+                    configurationOptions.add(Config.WithAssertion(buildAssertion(flowFile, nifiAssertionAttributeKey)));
+                }
+                Config.AssertionConfig assertionConfig = new Config.AssertionConfig();
+                PrivateKeyService privateKeyService = getPrivateKeyService(processContext);
+                if(privateKeyService!=null){
+                    getLogger().debug("adding signing configuration for assertion");
+                    PrivateKey privateKey = privateKeyService.getPrivateKey();
+                    RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey)privateKey;
+                    RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(rsaPrivateKey.getModulus(), rsaPrivateKey.getPublicExponent());
+                    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                    RSAPublicKey rsaPublicKey =(RSAPublicKey)keyFactory.generatePublic(publicKeySpec);
+                    assertionConfig.keyType = Config.AssertionConfig.KeyType.RS256;
+                    assertionConfig.rs256PrivateKeyForSigning = new RSAKey.Builder(rsaPublicKey).privateKey(rsaPrivateKey).build();
+                }
+                configurationOptions.add(Config.withAssertionConfig(assertionConfig));
+                TDFConfig config = Config.newTDFConfig(configurationOptions.toArray(new Consumer[0]));
+
                 //write ZTDF to FlowFile
                 FlowFile updatedFlowFile = processSession.write(flowFile, (inputStream, outputStream) -> {
                             try {

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
@@ -26,7 +26,7 @@ public class SimpleOpenTDFControllerService extends AbstractControllerService im
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
             .sensitive(false)
-            .description("OpenTDF Platform ENDPOINT")
+            .description("OpenTDF Platform ENDPOINT in GRPC compatible format (no protocol prefix)")
             .build();
 
     public static final PropertyDescriptor CLIENT_SECRET = new PropertyDescriptor.Builder()

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertFromZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertFromZTDFTest.java
@@ -1,11 +1,11 @@
 package io.opentdf.nifi;
 
+import io.opentdf.platform.sdk.Config;
 import io.opentdf.platform.sdk.SDK;
 import io.opentdf.platform.sdk.SDKBuilder;
 import io.opentdf.platform.sdk.TDF;
 import io.opentdf.platform.sdk.TDF.Reader;
 import nl.altindag.ssl.util.KeyStoreUtils;
-import org.apache.commons.compress.utils.IOUtils;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.nifi.ssl.SSLContextService;
 import org.apache.nifi.util.MockFlowFile;
@@ -78,7 +78,7 @@ class ConvertFromZTDFTest {
 
         ArgumentCaptor<SeekableByteChannel> seekableByteChannelArgumentCaptor = ArgumentCaptor.forClass(SeekableByteChannel.class);
         ArgumentCaptor<SDK.KAS> kasArgumentCaptor = ArgumentCaptor.forClass(SDK.KAS.class);
-
+        ArgumentCaptor<Config.AssertionConfig> assertionConfigCaptor = ArgumentCaptor.forClass(Config.AssertionConfig.class);
         Reader mockReader = mock(Reader.class);
 
         ArgumentCaptor<OutputStream> outputStreamArgumentCaptor = ArgumentCaptor.forClass(OutputStream.class);
@@ -95,11 +95,12 @@ class ConvertFromZTDFTest {
             ByteBuffer bb = ByteBuffer.allocate((int)seekableByteChannel.size());
             seekableByteChannel.read(bb);
             messages.add(new String(bb.array()));
-            SDK.KAS kas = invocationOnMock.getArgument(1);
+            SDK.KAS kas = invocationOnMock.getArgument(2);
             assertNotNull(kas, "KAS is not null");
             assertSame(mockKAS, kas, "Expected KAS passed in");
             return mockReader;
         }).when(mockTDF).loadTDF(seekableByteChannelArgumentCaptor.capture(),
+                assertionConfigCaptor.capture(),
                 kasArgumentCaptor.capture());
         MockFlowFile messageOne = runner.enqueue("message one".getBytes());
         MockFlowFile messageTwo = runner.enqueue("message two".getBytes());

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
@@ -17,8 +17,6 @@ import java.io.OutputStream;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static io.opentdf.nifi.AbstractTDFProcessor.OPENTDF_CONFIG_SERVICE;
-import static io.opentdf.nifi.SimpleOpenTDFControllerService.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
@@ -135,6 +135,7 @@ class ConvertToZTDFTest {
         Config.AssertionConfig assertionConfig = captures.configArgumentCaptor.getValue().assertionConfig;
         assertNotNull(assertionConfig, "Assertion configuration present");
         assertNotNull(assertionConfig.rs256PrivateKeyForSigning, "signing key present");
+        assertNotNull(assertionConfig.rs256PublicKeyForVerifying, "validation key present");
         assertEquals(assertionConfig.keyType, Config.AssertionConfig.KeyType.RS256);
         List<Assertion> assertions = captures.configArgumentCaptor.getValue().assertionList;
         assertEquals(assertions.size(), 1);

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
@@ -1,9 +1,12 @@
 package io.opentdf.nifi;
 
+import com.nimbusds.jose.JOSEException;
+import io.opentdf.platform.sdk.Assertion;
 import io.opentdf.platform.sdk.Config;
 import io.opentdf.platform.sdk.SDK;
 import io.opentdf.platform.sdk.TDF;
 import org.apache.commons.io.IOUtils;
+import org.apache.nifi.key.service.api.PrivateKeyService;
 import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.util.MockFlowFile;
 import org.apache.nifi.util.TestRunner;
@@ -12,8 +15,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -34,43 +41,8 @@ class ConvertToZTDFTest {
     @Test
     public void testToTDF() throws Exception {
         TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
-        ((MockRunner) runner.getProcessor()).mockSDK = mockSDK;
-        ((MockRunner) runner.getProcessor()).mockTDF = mockTDF;
-        runner.setProperty(ConvertToZTDF.KAS_URL, "https://kas1");
         Utils.setupTDFControllerService(runner);
-        runner.assertValid();
-
-        SDK.Services mockServices = mock(SDK.Services.class);
-        SDK.KAS mockKAS = mock(SDK.KAS.class);
-        when(mockSDK.getServices()).thenReturn(mockServices);
-        when(mockServices.kas()).thenReturn(mockKAS);
-
-        ArgumentCaptor<InputStream> inputStreamArgumentCaptor = ArgumentCaptor.forClass(InputStream.class);
-        ArgumentCaptor<OutputStream> outputStreamArgumentCaptor = ArgumentCaptor.forClass(OutputStream.class);
-        ArgumentCaptor<SDK.KAS> kasArgumentCaptor = ArgumentCaptor.forClass(SDK.KAS.class);
-        ArgumentCaptor<Config.TDFConfig> configArgumentCaptor = ArgumentCaptor.forClass(Config.TDFConfig.class);
-
-        doAnswer(invocationOnMock -> {
-            InputStream inputStream = invocationOnMock.getArgument(0);
-            OutputStream outputStream = invocationOnMock.getArgument(1);
-            Config.TDFConfig config = invocationOnMock.getArgument(2);
-            SDK.KAS kas = invocationOnMock.getArgument(3);
-            byte[] b = IOUtils.toByteArray(inputStream);
-            outputStream.write(("TDF:" + new String(b)).getBytes());
-            assertNotNull(kas, "KAS is not null");
-            assertSame(mockKAS, kas, "Expected KAS passed in");
-            if (new String(b).equals("message two")) {
-                assertEquals(2, config.attributes.size());
-                assertTrue(config.attributes.containsAll(Arrays.asList("https://example.org/attr/one/value/a", "https://example.org/attr/one/value/b")));
-            } else {
-                assertEquals(1, config.attributes.size());
-                assertTrue(config.attributes.contains("https://example.org/attr/one/value/c"));
-            }
-            return null;
-        }).when(mockTDF).createTDF(inputStreamArgumentCaptor.capture(),
-                outputStreamArgumentCaptor.capture(),
-                configArgumentCaptor.capture(),
-                kasArgumentCaptor.capture());
+        Captures captures = commonProcessorTestSetup(runner);
 
         //message one has no attribute
         MockFlowFile messageOne = runner.enqueue("message one".getBytes());
@@ -96,6 +68,130 @@ class ConvertToZTDFTest {
         assertEquals(1, flowFileList.size(), "One flowfile for failure relationship");
         assertEquals(1, flowFileList.stream().filter(x -> x.getAttribute("filename").equals(messageOne.getAttribute("filename")))
                 .filter(x -> x.getContent().equals("message one")).count());
+    }
+
+
+    @Test
+    public void testToTDF_WithAssertionsOn_None_Provided() throws Exception {
+        TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
+        runner.setProperty(ConvertToZTDF.SIGN_ASSERTIONS, "true");
+        PrivateKeyService privateKeyService = mock(PrivateKeyService.class);
+        when(privateKeyService.validate(any())).thenReturn(Collections.emptyList());
+        when(privateKeyService.getIdentifier()).thenReturn(ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE.getName());
+        runner.addControllerService(ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE.getName(), privateKeyService, new HashMap<>());
+        runner.enableControllerService(privateKeyService);
+        runner.setProperty(ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE, ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE.getName());
+        Utils.setupTDFControllerService(runner);
+        Captures captures = commonProcessorTestSetup(runner);
+        runner.enqueue("message two".getBytes(), Map.of(ConvertToZTDF.TDF_ATTRIBUTE,
+                "https://example.org/attr/one/value/a,https://example.org/attr/one/value/b"));
+        runner.run(1);
+        Config.AssertionConfig assertionConfig = captures.configArgumentCaptor.getValue().assertionConfig;
+        assertNotNull(assertionConfig, "Assertion configuration present");
+        assertNull(assertionConfig.rs256PrivateKeyForSigning, "no signing key");
+        List<Assertion> assertions = captures.configArgumentCaptor.getValue().assertionList;
+        assertTrue(assertions.isEmpty(), "no assertions");
+        List<MockFlowFile> flowFileList =
+                runner.getFlowFilesForRelationship(ConvertFromZTDF.REL_SUCCESS);
+        assertEquals(1, flowFileList.size(), "one success flow file");
+    }
+
+
+    @Test
+    public void testToTDF_WithAssertionsOn_And_Assertions_Provided() throws Exception {
+        TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
+        runner.setProperty(ConvertToZTDF.SIGN_ASSERTIONS, "true");
+        PrivateKeyService privateKeyService = mock(PrivateKeyService.class);
+        when(privateKeyService.validate(any())).thenReturn(Collections.emptyList());
+        when(privateKeyService.getIdentifier()).thenReturn(ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE.getName());
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair pair = generator.generateKeyPair();
+        PrivateKey privateKey = pair.getPrivate();
+
+        when(privateKeyService.getPrivateKey()).thenReturn(privateKey);
+        runner.addControllerService(ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE.getName(), privateKeyService, new HashMap<>());
+        runner.enableControllerService(privateKeyService);
+        runner.setProperty(ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE, ConvertToZTDF.PRIVATE_KEY_CONTROLLER_SERVICE.getName());
+        Utils.setupTDFControllerService(runner);
+        Captures captures = commonProcessorTestSetup(runner);
+
+        runner.enqueue("message two".getBytes(), Map.of(ConvertToZTDF.TDF_ATTRIBUTE,
+                "https://example.org/attr/one/value/a,https://example.org/attr/one/value/b", ConvertToZTDF.TDF_ASSERTION_PREFIX + "1",
+                """
+                        {
+                        "id": "1111",
+                        "type": "Handling",
+                        "appliesToState": "unencrypted",
+                        "scope": "PAYL",
+                        "statement": {
+                            "value": "a test assertion",
+                            "format": "sample"
+                          }
+                        }
+                        """));
+        runner.run(1);
+        Config.AssertionConfig assertionConfig = captures.configArgumentCaptor.getValue().assertionConfig;
+        assertNotNull(assertionConfig, "Assertion configuration present");
+        assertNotNull(assertionConfig.rs256PrivateKeyForSigning, "signing key present");
+        assertEquals(assertionConfig.keyType, Config.AssertionConfig.KeyType.RS256);
+        List<Assertion> assertions = captures.configArgumentCaptor.getValue().assertionList;
+        assertEquals(assertions.size(), 1);
+        assertEquals("a test assertion", assertions.get(0).statement.value);
+        assertEquals("sample", assertions.get(0).statement.format);
+        assertEquals("PAYL", assertions.get(0).scope);
+        assertEquals("unencrypted", assertions.get(0).appliesToState);
+        assertEquals("Handling", assertions.get(0).type);
+        assertEquals("1111", assertions.get(0).id);
+        List<MockFlowFile> flowFileList =
+                runner.getFlowFilesForRelationship(ConvertFromZTDF.REL_SUCCESS);
+        assertEquals(1, flowFileList.size(), "one success flow file");
+    }
+
+    private Captures commonProcessorTestSetup(TestRunner runner) throws IOException, JOSEException {
+        ((ConvertToZTDFTest.MockRunner) runner.getProcessor()).mockSDK = mockSDK;
+        ((ConvertToZTDFTest.MockRunner) runner.getProcessor()).mockTDF = mockTDF;
+        runner.setProperty(ConvertToZTDF.KAS_URL, "https://kas1");
+
+        runner.assertValid();
+
+        SDK.Services mockServices = mock(SDK.Services.class);
+        SDK.KAS mockKAS = mock(SDK.KAS.class);
+        when(mockSDK.getServices()).thenReturn(mockServices);
+        when(mockServices.kas()).thenReturn(mockKAS);
+
+        Captures captures = new Captures();
+
+        doAnswer(invocationOnMock -> {
+            InputStream inputStream = invocationOnMock.getArgument(0);
+            OutputStream outputStream = invocationOnMock.getArgument(1);
+            Config.TDFConfig config = invocationOnMock.getArgument(2);
+            SDK.KAS kas = invocationOnMock.getArgument(3);
+            byte[] b = IOUtils.toByteArray(inputStream);
+            outputStream.write(("TDF:" + new String(b)).getBytes());
+            assertNotNull(kas, "KAS is not null");
+            assertSame(mockKAS, kas, "Expected KAS passed in");
+            if (new String(b).equals("message two")) {
+                assertEquals(2, config.attributes.size());
+                assertTrue(config.attributes.containsAll(Arrays.asList("https://example.org/attr/one/value/a", "https://example.org/attr/one/value/b")));
+            } else {
+                assertEquals(1, config.attributes.size());
+                assertTrue(config.attributes.contains("https://example.org/attr/one/value/c"));
+            }
+            return null;
+        }).when(mockTDF).createTDF(captures.inputStreamArgumentCaptor.capture(),
+                captures.outputStreamArgumentCaptor.capture(),
+                captures.configArgumentCaptor.capture(),
+                captures.kasArgumentCaptor.capture());
+        return captures;
+    }
+
+    static class Captures {
+        ArgumentCaptor<InputStream> inputStreamArgumentCaptor = ArgumentCaptor.forClass(InputStream.class);
+        ArgumentCaptor<OutputStream> outputStreamArgumentCaptor = ArgumentCaptor.forClass(OutputStream.class);
+        ArgumentCaptor<SDK.KAS> kasArgumentCaptor = ArgumentCaptor.forClass(SDK.KAS.class);
+        ArgumentCaptor<Config.TDFConfig> configArgumentCaptor = ArgumentCaptor.forClass(Config.TDFConfig.class);
     }
 
     public static class MockRunner extends ConvertToZTDF {

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>io.opentdf.platform</groupId>
                 <artifactId>sdk</artifactId>
-                <version>0.1.0</version>
+                <version>0.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Address [Add Assertions](#10) 

- Point to upstream opentdf java-sdk 0.2.0
- Add properties to ConvertToZTDF:
    -  to support Assertion input via NiFi attributes
    -  configure signing on/off
    -  use of the NiFi Private Key Service to locate and use a key pair for assertion signing