### PR TITLE
ci: Maven Central release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,8 +42,8 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
         with:
-          java-version: "11"
-          distribution: "adopt"
+          java-version: "21"
+          distribution: "temurin"
           # write settings.xml
           server-id: github
           server-username: GITHUB_ACTOR
@@ -62,8 +62,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
         with:
-          java-version: "11"
-          distribution: "adopt"
+          java-version: "21"
+          distribution: "temurin"
           # write settings.xml
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [created]
 
 permissions:
   contents: read
@@ -35,8 +37,44 @@ jobs:
           java-version: "21"
           distribution: "temurin"
           server-id: github
-      - name: Publish package
-        run: mvn --batch-mode deploy -s settings.xml
+      # stage maven profile
+      - name: Set up JDK to publish to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          # write settings.xml
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+          gpg-private-key: ${{ secrets.GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Publish to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        run: mvn --batch-mode deploy -DskipTests -P stage
+        env:
+          GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}
+      # release maven profile
+      - name: Set up JDK to publish to Maven Central
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/setup-java@5896cecc08fd8a1fbdfaf517e29b571164b031f7
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          # write settings.xml
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Publish to Maven Central
+        if: startsWith(github.ref, 'refs/tags/')
+        run: mvn --batch-mode deploy -DskipTests -P release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,17 @@
             <url>https://github.com/opentdf/nifi/blob/main/LICENSE</url>
         </license>
     </licenses>
+    <developers>
+        <developer>
+            <organization>Virtru</organization>
+            <organizationUrl>https://www.virtru.com</organizationUrl>
+        </developer>
+    </developers>
+    <scm>
+        <connection>scm:git:https://github.com/opentdf/nifi.git</connection>
+        <developerConnection>scm:git:git@github.com:opentdf/nifi.git</developerConnection>
+        <url>https://github.com/opentdf/nifi/tree/main/</url>
+    </scm>
     <properties>
         <nifi.version>1.23.1</nifi.version>
         <junit.version>5.10.0</junit.version>
@@ -184,23 +195,68 @@
     </repositories>
     <profiles>
         <profile>
-            <id>ghcr</id>
+            <id>stage</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <distributionManagement>
                 <repository>
                     <id>github</id>
-                    <name>ghcr</name>
+                    <name>GitHub opentdf Apache Maven Packages</name>
                     <url>https://maven.pkg.github.com/opentdf/nifi</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
                 </repository>
-                <snapshotRepository>
-                    <id>github</id>
-                    <name>ghcr</name>
-                    <url>https://maven.pkg.github.com/opentdf/nifi</url>
-                </snapshotRepository>
             </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>3.1.2</version>
+                        <configuration>
+                            <repositoryId>github-pkg</repositoryId>
+                            <url>https://maven.pkg.github.com/opentdf/nifi</url>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
-
+        <profile>
+            <id>release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Publish to Maven Central Deploy -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.6.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <!-- defined in settings.xml -->
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                    <!-- Exclude from lifecycle, phase none -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>3.1.2</version>
+                        <executions>
+                            <execution>
+                                <id>default-deploy</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow to distinguish between publishing to GitHub Packages and Maven Central. It also updates the `pom.xml` with separate Maven profiles for staging and releasing, incorporating necessary plugins and settings for both deployment targets.

DSP-154