### PR TITLE
fix: Sonarcloud, tests, documentation

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -41,9 +41,15 @@ jobs:
           java-version: "21"
           distribution: "temurin"
           server-id: github
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Maven Verify
         run: |
-          mvn --batch-mode clean install -s settings.xml
+          mvn --batch-mode clean verify -s settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -61,6 +67,18 @@ jobs:
           java-version: "17"
           distribution: "temurin"
           server-id: github
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Maven Test Coverage
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/nifi-tdf-controller-services-api-nar/pom.xml
+++ b/nifi-tdf-controller-services-api-nar/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>io.opentdf.nifi</groupId>
         <artifactId>nifi-pom</artifactId>
@@ -28,6 +27,25 @@
         </dependency>
     </dependencies>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.12</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent</id>
+                            <phase>none</phase>
+                        </execution>
+                        <execution>
+                            <id>default-report</id>
+                            <phase>none</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.nifi</groupId>

--- a/nifi-tdf-controller-services-api-nar/pom.xml
+++ b/nifi-tdf-controller-services-api-nar/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>io.opentdf.nifi</groupId>
         <artifactId>nifi-pom</artifactId>

--- a/nifi-tdf-processors/pom.xml
+++ b/nifi-tdf-processors/pom.xml
@@ -97,37 +97,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                        <configuration>
-                            <destFile>${project.parent.basedir}/target/jacoco.exec</destFile>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>${project.parent.basedir}/target/jacoco.exec</dataFile>
-                            <formats>
-                                <format>XML</format>
-                            </formats>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
@@ -228,18 +228,4 @@ public abstract class AbstractTDFProcessor extends AbstractProcessor {
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return List.of(SSL_CONTEXT_SERVICE, OPENTDF_CONFIG_SERVICE, FLOWFILE_PULL_SIZE);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        AbstractTDFProcessor that = (AbstractTDFProcessor) o;
-        return Objects.equals(sdk, that.sdk);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), sdk);
-    }
 }

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromNanoTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromNanoTDF.java
@@ -12,10 +12,27 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+/**
+ * A processor for decrypting NanoTDF flow file content using the OpenTDF framework.
+ * <p>
+ * This processor reads encrypted NanoTDF data from incoming flow files and decrypts
+ * it using the associated SDK. The decrypted content is then written back into the
+ * flow file and routed to the success relationship. If decryption fails, the flow file
+ * is routed to the failure relationship.
+ */
 @CapabilityDescription("Decrypts NanoTDF flow file content")
 @Tags({"NanoTDF", "OpenTDF", "Decrypt", "Data Centric Security"})
 public class ConvertFromNanoTDF extends AbstractTDFProcessor {
 
+    /**
+     * Processes the provided list of flow files by decrypting their content using the NanoTDF protocol.
+     * If decryption succeeds, the flow file is routed to the success relationship; otherwise, it is routed to the failure relationship.
+     *
+     * @param processContext the NiFi ProcessContext which provides configuration and controller services
+     * @param processSession the ProcessSession which provides mechanisms for reading, writing, transferring, and penalizing flow files
+     * @param flowFiles the list of FlowFile objects to be processed
+     * @throws ProcessException if any error occurs during the processing of flow files
+     */
     @Override
     public void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -16,12 +16,46 @@ import java.nio.channels.SeekableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 
-
+/**
+ * Converts and decrypts ZTDF (Zero Trust Data Format) flow file content.
+ * This class takes encrypted ZTDF content and decrypts it,
+ * transferring the decrypted data to a specified success relationship.
+ * If an error occurs during decryption, it transfers the flow file to a failure relationship.
+ * <p>
+ * This processor uses TDF (Trusted Data Format) SDK for decryption and
+ * requires configuration of assertion verification keys to verify
+ * the integrity and authenticity of the encrypted data.
+ * <p>
+ * It provides the primary method `processFlowFiles` which reads the encrypted
+ * content from incoming flow files, decrypts it, and writes the decrypted
+ * content back to the flow files.
+ * <p>
+ * The method `processFlowFiles` performs the following steps:
+ * 1. Retrieves the TDF SDK instance.
+ * 2. Reads the entire encrypted content of each flow file into an in-memory byte channel.
+ * 3. Uses TDF Reader to load and decrypt the content.
+ * 4. Writes the decrypted content back into the flow file and transfers it to the success relationship.
+ * 5. If any error occurs during the decryption process, logs the error and transfers the flow file to the failure relationship.
+ */
 @CapabilityDescription("Decrypts ZTDF flow file content")
 @Tags({"ZTDF", "Zero Trust Data Format", "OpenTDF", "Decrypt", "Data Centric Security"})
 public class ConvertFromZTDF extends AbstractTDFProcessor {
 
 
+    /**
+     * Processes a list of flow files by decrypting their content using the TDF (Trusted Data Format) SDK.
+     * For each flow file in the provided list, the following steps are executed:
+     * 1. Reads the entire encrypted content of the flow file into an in-memory byte channel.
+     * 2. Uses a TDF Reader to load and decrypt the content using the SDK.
+     * 3. Writes the decrypted content back to the flow file.
+     * 4. Transfers the successfully decrypted flow files to the success relationship.
+     * 5. In case of an error during decryption, logs the error and transfers the flow file to the failure relationship.
+     *
+     * @param processContext the NiFi ProcessContext providing configuration and controller services.
+     * @param processSession the NiFi ProcessSession used to read, write, and transfer flow files.
+     * @param flowFiles a list of flow files to be decrypted.
+     * @throws ProcessException if an error occurs during the decryption process.
+     */
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToNanoTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToNanoTDF.java
@@ -20,6 +20,25 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Processor for converting the content of a FlowFile into a NanoTDF (Trusted Data Format).
+ * <p>
+ * This class extends AbstractToProcessor and handles the encryption of FlowFile content into NanoTDF,
+ * applying specified KAS (Key Access Service) URLs and data attributes as defined in the flow file attributes
+ * or processor properties.
+ * <p>
+ * Relationships:
+ * - REL_SUCCESS: When the conversion to NanoTDF is successful.
+ * - REL_FAILURE: When the conversion to NanoTDF fails.
+ * - REL_FLOWFILE_EXCEEDS_NANO_SIZE: When the content size exceeds the maximum allowed size for NanoTDF.
+ * <p>
+ * Property Descriptors:
+ * - Inherited from AbstractToProcessor (e.g., KAS URL, SSL_CONTEXT_SERVICE, OPENTDF_CONFIG_SERVICE, etc.)
+ * <p>
+ * Reads Attributes:
+ * - kas_url: The Key Access Server (KAS) URL used for TDF creation. Overrides the default KAS URL property.
+ * - tdf_attribute: A comma-separated list of data attributes added to the created TDF Data Policy.
+ */
 @CapabilityDescription("Transforms flow file content into a NanoTDF")
 @Tags({"NanoTDF", "OpenTDF", "Encrypt", "Data Centric Security"})
 @ReadsAttributes(value = {
@@ -30,19 +49,43 @@ import java.util.Set;
 })
 public class ConvertToNanoTDF extends AbstractToProcessor {
 
+    /**
+     * Defines a relationship indicating that NanoTDF creation has failed
+     * due to the content size exceeding the maximum allowed NanoTDF size threshold.
+     */
     public static final Relationship REL_FLOWFILE_EXCEEDS_NANO_SIZE = new Relationship.Builder()
             .name("exceeds_size_limit")
             .description("NanoTDF creation failed due to the content size exceeding the max NanoTDF size threshold")
             .build();
 
+    /**
+     * Represents the maximum allowable size for processing a flow file in nano TDF conversion.
+     * Value is set to 16 MB.
+     */
     static final long MAX_SIZE = 16777218;
 
+    /**
+     * Retrieves all the relationships defined in the ConvertToNanoTDF processor.
+     *
+     * @return a Set of Relationship objects representing the different relationships for the processor.
+     */
     @Override
     public Set<Relationship> getRelationships() {
         return new HashSet<>(Arrays.asList(REL_SUCCESS, REL_FAILURE, REL_FLOWFILE_EXCEEDS_NANO_SIZE));
     }
 
 
+    /**
+     * Processes a list of FlowFiles to convert them to NanoTDF format.
+     * If a FlowFile's size exceeds the maximum allowed size, it is routed to a specific relationship.
+     * Otherwise, it attempts to convert the FlowFile's content and transfer it to a success relationship.
+     * In case of an error during processing, the FlowFile is routed to a failure relationship.
+     *
+     * @param processContext the NiFi ProcessContext providing necessary configuration and controller services.
+     * @param processSession the NiFi ProcessSession representing a transaction context for the processing of FlowFiles.
+     * @param flowFiles a list of FlowFiles to be processed.
+     * @throws ProcessException if an error occurs during the processing of the FlowFiles.
+     */
     @Override
     public void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);
@@ -50,6 +93,8 @@ public class ConvertToNanoTDF extends AbstractToProcessor {
             try {
                 var kasInfoList = getKASInfoFromKASURLs(getKasUrl(flowFile, processContext));
                 Set<String> dataAttributes = getDataAttributes(flowFile);
+                // Config.newNanoTDFConfig is correctly handling the varargs
+                @SuppressWarnings("unchecked")
                 Config.NanoTDFConfig config = Config.newNanoTDFConfig(
                         Config.withNanoKasInformation(kasInfoList.toArray(new Config.KASInfo[0])),
                         Config.witDataAttributes(dataAttributes.toArray(new String[0]))

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -140,9 +140,10 @@ public class ConvertToZTDF extends AbstractToProcessor {
         Map<?,?> assertionMap = gson.fromJson(assertionJson, Map.class);
         AssertionConfig assertionConfig = new AssertionConfig();
         assertionConfig.id = assertionMap.containsKey("id") ? (String)assertionMap.get("id") : null;
-        assertionConfig.type = assertionMap.containsKey("type") ? assertionTypeMap.get(assertionMap.get("type")) : null;
-        assertionConfig.scope =assertionMap.containsKey("scope") ? assertionScopeMap.get(assertionMap.get("scope")) : null;
-        assertionConfig.appliesToState = assertionMap.containsKey("appliesToState") ? assertionAppliesToStateMap.get(assertionMap.get("appliesToState")): null;
+
+        populateFieldFromMap(assertionMap, "type", assertionTypeMap, value -> assertionConfig.type = (AssertionConfig.Type) value);
+        populateFieldFromMap(assertionMap, "scope", assertionScopeMap, value -> assertionConfig.scope = (AssertionConfig.Scope) value);
+        populateFieldFromMap(assertionMap, "appliesToState", assertionAppliesToStateMap, value -> assertionConfig.appliesToState = (AssertionConfig.AppliesToState) value);
         assertionConfig.statement = new AssertionConfig.Statement();
 
         Map<?,?> statementMap = (Map<?,?>)assertionMap.get("statement");
@@ -167,6 +168,14 @@ public class ConvertToZTDF extends AbstractToProcessor {
             throw new Exception("assertion type is required");
         }
         return assertionConfig;
+    }
+
+    private void populateFieldFromMap(Map<?, ?> sourceMap, String key, Map<?, ?> destinationMap, Consumer<Object> setter) {
+        if (sourceMap.containsKey(key)) {
+            setter.accept(destinationMap.get(sourceMap.get(key)));
+        } else {
+            setter.accept(null);
+        }
     }
 
     /**
@@ -239,19 +248,5 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 assertionConfig.assertionKey = new AssertionConfig.AssertionKey(AssertionConfig.AssertionKeyAlg.RS256, privateKey);
             }
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        ConvertToZTDF that = (ConvertToZTDF) o;
-        return Objects.equals(gson, that.gson) && Objects.equals(assertionTypeMap, that.assertionTypeMap) && Objects.equals(assertionScopeMap, that.assertionScopeMap) && Objects.equals(assertionAppliesToStateMap, that.assertionAppliesToStateMap);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), gson, assertionTypeMap, assertionScopeMap, assertionAppliesToStateMap);
     }
 }

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -209,8 +209,8 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 FlowFile updatedFlowFile = processSession.write(flowFile, (inputStream, outputStream) -> {
                             try {
                                 getTDF().createTDF(inputStream, outputStream, config, sdk.getServices().kas(), sdk.getServices().attributes());
-                            } catch (InterruptedException e) { // Compliant; the interrupted state is restored
-                                getLogger().error("Interrupted!", e);
+                            } catch (InterruptedException e) {
+                                getLogger().error("Interrupted inner", e);
                                 Thread.currentThread().interrupt();
                             } catch (Exception e) {
                                 getLogger().error("error creating ZTDF", e);
@@ -220,6 +220,9 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 );
                 updatedFlowFile = processSession.putAttribute(updatedFlowFile, "mime.type", "application/ztdf+zip");
                 processSession.transfer(updatedFlowFile, REL_SUCCESS);
+            } catch (InterruptedException e) {
+                getLogger().error("Interrupted outer", e);
+                Thread.currentThread().interrupt();
             } catch (Exception e) {
                 getLogger().error(flowFile.getId() + ": error converting plain text to ZTDF", e);
                 processSession.transfer(flowFile, REL_FAILURE);

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -20,12 +20,15 @@ import org.apache.nifi.processor.ProcessSession;
 import org.apache.nifi.processor.exception.ProcessException;
 
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.security.spec.InvalidKeySpecException;
 import java.util.*;
 import java.util.function.Consumer;
 
+/**
+ * The ConvertToZTDF class transforms flow file content into a ZTDF (Zero Trust Data Format). 
+ * It builds assertions from flow file attributes and configures TDF options based on these assertions.
+ * This class supports property descriptors and signing of assertions.
+ */
 @CapabilityDescription("Transforms flow file content into a ZTDF")
 @Tags({"ZTDF", "OpenTDF", "Zero Trust Data Format", "Encrypt", "Data Centric Security"})
 @ReadsAttributes(value = {
@@ -49,6 +52,17 @@ import java.util.function.Consumer;
 })
 public class ConvertToZTDF extends AbstractToProcessor {
 
+    /**
+     * Property descriptor for the "Sign Assertions" feature in the ConvertToZTDF processor. This property allows specifying whether 
+     * the assertions should be signed or not. It is not a required property and defaults to "false".
+     * <p>
+     * - Name: Sign Assertions
+     * - Description: sign assertions
+     * - Required: false
+     * - Default Value: false
+     * - Allowable Values: true, false
+     * - Expression Language Supported: {@link ExpressionLanguageScope#VARIABLE_REGISTRY}
+     */
     public static final PropertyDescriptor SIGN_ASSERTIONS = new org.apache.nifi.components.PropertyDescriptor.Builder()
             .name("Sign Assertions")
             .description("sign assertions")
@@ -58,6 +72,15 @@ public class ConvertToZTDF extends AbstractToProcessor {
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
             .build();
 
+    /**
+     * Property descriptor for the "Private Key Controller Service".
+     * <p>
+     * This descriptor defines an optional Private Key Service which is required
+     * for assertion signing. The property is compulsory and identifies the
+     * PrivateKeyService class as the controller service. It is dependent on
+     * the SIGN_ASSERTIONS property being set to "true" and supports expression
+     * language in the variable registry scope.
+     */
     public static final PropertyDescriptor PRIVATE_KEY_CONTROLLER_SERVICE = new org.apache.nifi.components.PropertyDescriptor.Builder()
             .name("Private Key Controller Service")
             .description("Optional Private Key Service; this is need for assertion signing")
@@ -68,12 +91,23 @@ public class ConvertToZTDF extends AbstractToProcessor {
             .build();
 
 
+    /**
+     * Retrieves the PrivateKeyService from the given process context if it is set.
+     *
+     * @param processContext the NiFi ProcessContext providing necessary configuration and controller services.
+     * @return an instance of PrivateKeyService if it is set in the process context, otherwise null.
+     */
     PrivateKeyService getPrivateKeyService(ProcessContext processContext) {
         return processContext.getProperty(PRIVATE_KEY_CONTROLLER_SERVICE).isSet() ?
                 processContext.getProperty(PRIVATE_KEY_CONTROLLER_SERVICE)
                         .asControllerService(PrivateKeyService.class) : null;
     }
 
+    /**
+     * Retrieves a list of supported property descriptors for this processor.
+     *
+     * @return an unmodifiable list of PropertyDescriptor objects representing the supported properties.
+     */
     @Override
     public List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         List<PropertyDescriptor> propertyDescriptors = new ArrayList<>(super.getSupportedPropertyDescriptors());
@@ -91,9 +125,15 @@ public class ConvertToZTDF extends AbstractToProcessor {
     Map<String, AssertionConfig.AppliesToState> assertionAppliesToStateMap = Map.of("encrypted", AssertionConfig.AppliesToState.Encrypted,
             "unencrypted", AssertionConfig.AppliesToState.Unencrypted);
     /**
-     * Build an assertion config from the flow file attribute
-     * @return
-     * @throws Exception throw exception when assertion is not valid
+     * Builds an {@link AssertionConfig} instance from the given NiFi {@link ProcessContext} and {@link FlowFile},
+     * using the provided flowFile attribute name to retrieve relevant data. This method deserializes an assertion
+     * JSON string from the flowFile attribute, populates the {@link AssertionConfig}, and performs necessary validations.
+     *
+     * @param processContext the NiFi ProcessContext providing necessary configuration and controller services
+     * @param flowFile the NiFi FlowFile containing the assertion JSON string in its attributes
+     * @param flowFileAttributeName the name of the attribute in the flowFile which contains the assertion JSON string
+     * @return an {@link AssertionConfig} instance populated with values from the assertion JSON string in the flowFile attribute
+     * @throws Exception if any essential assertion information is missing or invalid 
      */
     AssertionConfig buildAssertion(ProcessContext processContext, FlowFile flowFile, String flowFileAttributeName) throws Exception{
         String assertionJson = flowFile.getAttribute(flowFileAttributeName);
@@ -129,6 +169,14 @@ public class ConvertToZTDF extends AbstractToProcessor {
         return assertionConfig;
     }
 
+    /**
+     * Processes a list of FlowFiles to convert them into TDF (Trusted Data Format) files.
+     *
+     * @param processContext the NiFi ProcessContext providing necessary configuration and controller services.
+     * @param processSession the NiFi ProcessSession used to interact with the FlowFiles.
+     * @param flowFiles the list of FlowFiles to be processed.
+     * @throws ProcessException if there are any errors during the processing of the FlowFiles.
+     */
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);
@@ -144,12 +192,17 @@ public class ConvertToZTDF extends AbstractToProcessor {
                     getLogger().debug(String.format("Adding assertion for NiFi attribute = %s", nifiAssertionAttributeKey));
                     configurationOptions.add(Config.withAssertionConfig(buildAssertion(processContext, flowFile, nifiAssertionAttributeKey)));
                 }
+                // Config.newTDFConfig is correctly handling the varargs
+                @SuppressWarnings("unchecked")
                 TDFConfig config = Config.newTDFConfig(configurationOptions.toArray(new Consumer[0]));
 
                 //write ZTDF to FlowFile
                 FlowFile updatedFlowFile = processSession.write(flowFile, (inputStream, outputStream) -> {
                             try {
                                 getTDF().createTDF(inputStream, outputStream, config, sdk.getServices().kas(), sdk.getServices().attributes());
+                            } catch (InterruptedException e) { // Compliant; the interrupted state is restored
+                                getLogger().error("Interrupted!", e);
+                                Thread.currentThread().interrupt();
                             } catch (Exception e) {
                                 getLogger().error("error creating ZTDF", e);
                                 throw new IOException(e);
@@ -165,10 +218,18 @@ public class ConvertToZTDF extends AbstractToProcessor {
         }
     }
 
-    private void addSigningInfoToAssertionConfig(ProcessContext processContext, AssertionConfig assertionConfig) throws NoSuchAlgorithmException, InvalidKeySpecException {
-        Optional<PropertyValue> signAssertions = getPropertyValue(SIGN_ASSERTIONS, processContext);
+    /**
+     * Adds signing information to the given AssertionConfig if the signing property is enabled 
+     * in the ProcessContext and the private key service is available.
+     *
+     * @param processContext the NiFi ProcessContext providing necessary configuration 
+     *                       and controller services.
+     * @param assertionConfig the AssertionConfig to which the signing information will be added.
+     */
+    private void addSigningInfoToAssertionConfig(ProcessContext processContext, AssertionConfig assertionConfig) {
+        Optional<PropertyValue> signAssertions = getPropertyValue(processContext);
         //populate assertion signing config only when sign assertions property is true and assertions exist
-        if (signAssertions.isPresent() && signAssertions.get().asBoolean()) {
+        if (signAssertions.isPresent() && Boolean.TRUE.equals(signAssertions.get().asBoolean())) {
             getLogger().debug("signed assertions is active");
             PrivateKeyService privateKeyService = getPrivateKeyService(processContext);
             if (privateKeyService != null) {
@@ -178,5 +239,19 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 assertionConfig.assertionKey = new AssertionConfig.AssertionKey(AssertionConfig.AssertionKeyAlg.RS256, privateKey);
             }
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ConvertToZTDF that = (ConvertToZTDF) o;
+        return Objects.equals(gson, that.gson) && Objects.equals(assertionTypeMap, that.assertionTypeMap) && Objects.equals(assertionScopeMap, that.assertionScopeMap) && Objects.equals(assertionAppliesToStateMap, that.assertionAppliesToStateMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), gson, assertionTypeMap, assertionScopeMap, assertionAppliesToStateMap);
     }
 }

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
@@ -1,6 +1,5 @@
 package io.opentdf.nifi;
 
-import java.util.Objects;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -154,19 +153,5 @@ public class SimpleOpenTDFControllerService extends AbstractControllerService im
     @Override
     public Config getConfig() throws ProcessException {
         return config;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        SimpleOpenTDFControllerService that = (SimpleOpenTDFControllerService) o;
-        return Objects.equals(config, that.config);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), config);
     }
 }

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
@@ -1,5 +1,6 @@
 package io.opentdf.nifi;
 
+import java.util.Objects;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
 import org.apache.nifi.annotation.lifecycle.OnEnabled;
@@ -15,10 +16,17 @@ import org.apache.nifi.reporting.InitializationException;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Provides an implementation of the OpenTDFControllerService API for OpenTDF SDK Configuration Parameters.
+ */
 @Tags({"TDF", "ZTDF", "OpenTDF", "Configuration"})
 @CapabilityDescription("Provides An implementation of the OpenTDFControllerService API for OpenTDF SDK Configuration Parameters")
 public class SimpleOpenTDFControllerService extends AbstractControllerService implements OpenTDFControllerService {
 
+    /**
+     * The endpoint of the OpenTDF platform in GRPC compatible format, excluding the protocol prefix.
+     * This is a required property and supports expression language within the scope of the variable registry.
+     */
     public static final PropertyDescriptor PLATFORM_ENDPOINT = new PropertyDescriptor.Builder()
             .name("platform-endpoint")
             .displayName("OpenTDF Platform ENDPOINT")
@@ -29,6 +37,14 @@ public class SimpleOpenTDFControllerService extends AbstractControllerService im
             .description("OpenTDF Platform ENDPOINT in GRPC compatible format (no protocol prefix)")
             .build();
 
+    /**
+     * The client secret used for authentication with the OpenTDF Platform.
+     * <p>
+     * This property is required and must be configured with a valid client secret.
+     * It supports expression language within the scope of the variable registry, ensuring that the client secret
+     * can be dynamically set based on external configurations.
+     * The value of this property is sensitive and will be handled securely.
+     */
     public static final PropertyDescriptor CLIENT_SECRET = new PropertyDescriptor.Builder()
             .name("clientSecret")
             .displayName("Client Secret")
@@ -39,6 +55,11 @@ public class SimpleOpenTDFControllerService extends AbstractControllerService im
             .description("OpenTDF Platform Authentication Client Secret")
             .build();
 
+    /**
+     * Property for specifying the Client ID used for authentication against the OpenTDF Platform.
+     * This is a required field, and it must be non-empty. Expression language is supported for
+     * variable registry scope.
+     */
     public static final PropertyDescriptor CLIENT_ID = new PropertyDescriptor.Builder()
             .name("clientId")
             .displayName("Client ID")
@@ -50,6 +71,12 @@ public class SimpleOpenTDFControllerService extends AbstractControllerService im
             .build();
 
 
+    /**
+     * Configuration property that determines whether the connection to the OpenTDF Platform should use plaintext.
+     * This is a required property and can have a default value of "false".
+     * The acceptable values for this property are "true" and "false". It is not marked as sensitive.
+     * A non-empty validator is applied to ensure the property is not left blank.
+     */
     public static final PropertyDescriptor USE_PLAINTEXT = new PropertyDescriptor.Builder()
             .name("usePlaintext")
             .displayName("Platform Use Plaintext Connection")
@@ -63,26 +90,83 @@ public class SimpleOpenTDFControllerService extends AbstractControllerService im
 
     Config config = null;
 
+    /**
+     * Returns a list of property descriptors that are supported by this controller service.
+     *
+     * @return a list of PropertyDescriptor objects
+     */
     @Override
     protected List<PropertyDescriptor> getSupportedPropertyDescriptors() {
         return Arrays.asList(PLATFORM_ENDPOINT, CLIENT_ID, CLIENT_SECRET, USE_PLAINTEXT);
     }
 
+    /**
+     * Initializes the controller service with the provided configuration context.
+     *
+     * @param configurationContext the context containing configuration properties to be applied during service enablement
+     * @throws InitializationException if any required configuration property is missing or invalid
+     */
     @OnEnabled
     public void enabled(final ConfigurationContext configurationContext) throws InitializationException {
         config = new Config();
-        config.setClientId(getPropertyValue(configurationContext.getProperty(CLIENT_ID)).getValue());
-        config.setClientSecret(getPropertyValue(configurationContext.getProperty(CLIENT_SECRET)).getValue());
-        config.setPlatformEndpoint(getPropertyValue(configurationContext.getProperty(PLATFORM_ENDPOINT)).getValue());
-        config.setUsePlainText(getPropertyValue(configurationContext.getProperty(USE_PLAINTEXT)).asBoolean());
+
+        PropertyValue clientIdValue = getPropertyValue(configurationContext.getProperty(CLIENT_ID));
+        PropertyValue clientSecretValue = getPropertyValue(configurationContext.getProperty(CLIENT_SECRET));
+        PropertyValue platformEndpointValue = getPropertyValue(configurationContext.getProperty(PLATFORM_ENDPOINT));
+        PropertyValue usePlainTextValue = getPropertyValue(configurationContext.getProperty(USE_PLAINTEXT));
+
+        // Ensure that no required property is null
+        if (clientIdValue.getValue() == null ||
+                clientSecretValue.getValue() == null ||
+                platformEndpointValue.getValue() == null ||
+                usePlainTextValue == null) {
+            throw new InitializationException("One or more required properties are not configured properly.");
+        }
+
+        config.setClientId(clientIdValue.getValue());
+        config.setClientSecret(clientSecretValue.getValue());
+        config.setPlatformEndpoint(platformEndpointValue.getValue());
+
+        Boolean usePlainText = usePlainTextValue.asBoolean();
+        if (usePlainText == null) {
+            throw new InitializationException("The 'usePlaintext' property must be either 'true' or 'false'.");
+        }
+        config.setUsePlainText(usePlainText);
     }
 
+    /**
+     * Evaluates the provided PropertyValue and returns the result of the evaluation if expression language is present.
+     * Otherwise, it returns the original PropertyValue.
+     *
+     * @param propertyValue the PropertyValue object to be evaluated
+     * @return the evaluated PropertyValue if expression language is present, otherwise the original PropertyValue
+     */
     PropertyValue getPropertyValue(PropertyValue propertyValue) {
         return propertyValue.isExpressionLanguagePresent() ? propertyValue.evaluateAttributeExpressions() : propertyValue;
     }
 
+    /**
+     * Retrieves the current configuration settings for the OpenTDF controller service.
+     *
+     * @return the current Config object containing configuration properties
+     * @throws ProcessException if an error occurs while retrieving the configuration
+     */
     @Override
     public Config getConfig() throws ProcessException {
         return config;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        SimpleOpenTDFControllerService that = (SimpleOpenTDFControllerService) o;
+        return Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), config);
     }
 }

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertFromNanoTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertFromNanoTDFTest.java
@@ -37,7 +37,7 @@ class ConvertFromNanoTDFTest {
     }
 
     @Test
-    public void testConvertFromTDF() throws Exception {
+    void testConvertFromTDF() throws Exception {
         TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
         SDKBuilder mockSDKBuilder = mock(SDKBuilder.class);
         ((MockRunner) runner.getProcessor()).mockNanoTDF = mockNanoTDF;

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertFromZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertFromZTDFTest.java
@@ -37,7 +37,7 @@ class ConvertFromZTDFTest {
     }
 
     @Test
-    public void testConvertFromTDF() throws Exception {
+    void testConvertFromTDF() throws Exception {
         TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
         SDKBuilder mockSDKBuilder = mock(SDKBuilder.class);
         ((MockRunner) runner.getProcessor()).mockTDF = mockTDF;

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
@@ -39,10 +39,10 @@ class ConvertToZTDFTest {
     }
 
     @Test
-    public void testToTDF() throws Exception {
+    void testToTDF() throws Exception {
         TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
         Utils.setupTDFControllerService(runner);
-        Captures captures = commonProcessorTestSetup(runner);
+        commonProcessorTestSetup(runner);
 
         //message one has no attribute
         MockFlowFile messageOne = runner.enqueue("message one".getBytes());
@@ -72,7 +72,7 @@ class ConvertToZTDFTest {
 
 
     @Test
-    public void testToTDF_WithAssertionsOn_None_Provided() throws Exception {
+    void testToTDF_WithAssertionsOn_None_Provided() throws Exception {
         TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
         runner.setProperty(ConvertToZTDF.SIGN_ASSERTIONS, "true");
         PrivateKeyService privateKeyService = mock(PrivateKeyService.class);
@@ -95,7 +95,7 @@ class ConvertToZTDFTest {
 
 
     @Test
-    public void testToTDF_WithAssertionsOn_And_Assertions_Provided() throws Exception {
+    void testToTDF_WithAssertionsOn_And_Assertions_Provided() throws Exception {
         TestRunner runner = TestRunners.newTestRunner(MockRunner.class);
         runner.setProperty(ConvertToZTDF.SIGN_ASSERTIONS, "true");
         PrivateKeyService privateKeyService = mock(PrivateKeyService.class);
@@ -130,11 +130,11 @@ class ConvertToZTDFTest {
                         """));
         runner.run(1);
         List<AssertionConfig> assertionConfigList = captures.configArgumentCaptor.getValue().assertionConfigList;
-        assertEquals(assertionConfigList.size(), 1);
+        assertEquals(1, assertionConfigList.size());
         AssertionConfig assertionConfig = assertionConfigList.get(0);
         assertNotNull(assertionConfig, "Assertion configuration present");
         assertNotNull(assertionConfig.assertionKey.key, "signing key present");
-        assertEquals(assertionConfig.assertionKey.alg, AssertionConfig.AssertionKeyAlg.RS256);
+        assertEquals(AssertionConfig.AssertionKeyAlg.RS256, assertionConfig.assertionKey.alg);
         assertEquals("a test assertion", assertionConfig.statement.value);
         assertEquals("sample", assertionConfig.statement.format);
         assertEquals(AssertionConfig.Scope.Payload, assertionConfig.scope);
@@ -207,6 +207,4 @@ class ConvertToZTDFTest {
             return mockTDF;
         }
     }
-
-
 }

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/SimpleOpenTDFControllerServiceTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/SimpleOpenTDFControllerServiceTest.java
@@ -1,5 +1,69 @@
 package io.opentdf.nifi;
 
+import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.components.PropertyValue;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 class SimpleOpenTDFControllerServiceTest {
 
+    @Test
+    void testEnabledWithValidValues() throws InitializationException {
+        SimpleOpenTDFControllerService service = new SimpleOpenTDFControllerService();
+
+        ConfigurationContext context = Mockito.mock(ConfigurationContext.class);
+        PropertyValue clientID = Mockito.mock(PropertyValue.class);
+        PropertyValue clientSecret = Mockito.mock(PropertyValue.class);
+        PropertyValue platformEndpoint = Mockito.mock(PropertyValue.class);
+        PropertyValue usePlainText = Mockito.mock(PropertyValue.class);
+
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.CLIENT_ID)).thenReturn(clientID);
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.CLIENT_SECRET)).thenReturn(clientSecret);
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.PLATFORM_ENDPOINT)).thenReturn(platformEndpoint);
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.USE_PLAINTEXT)).thenReturn(usePlainText);
+
+        Mockito.when(clientID.getValue()).thenReturn("Valid client ID");
+        Mockito.when(clientSecret.getValue()).thenReturn("Valid client Secret");
+        Mockito.when(platformEndpoint.getValue()).thenReturn("Valid platform endpoint");
+        Mockito.when(usePlainText.asBoolean()).thenReturn(true);
+
+        service.enabled(context);
+
+        assertNotNull(service.getConfig());
+        assertEquals("Valid client ID", service.getConfig().getClientId());
+        assertEquals("Valid client Secret", service.getConfig().getClientSecret());
+        assertEquals("Valid platform endpoint", service.getConfig().getPlatformEndpoint());
+    }
+
+    @Test
+    void testEnabledWithInvalidValues() {
+        SimpleOpenTDFControllerService service = new SimpleOpenTDFControllerService();
+
+        ConfigurationContext context = Mockito.mock(ConfigurationContext.class);
+
+        // Mock property values with invalid data
+        PropertyValue clientID = Mockito.mock(PropertyValue.class);
+        PropertyValue clientSecret = Mockito.mock(PropertyValue.class);
+        PropertyValue platformEndpoint = Mockito.mock(PropertyValue.class);
+        PropertyValue usePlainText = Mockito.mock(PropertyValue.class);
+
+        // Return null for all properties to simulate invalid values
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.CLIENT_ID)).thenReturn(clientID);
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.CLIENT_SECRET)).thenReturn(clientSecret);
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.PLATFORM_ENDPOINT)).thenReturn(platformEndpoint);
+        Mockito.when(context.getProperty(SimpleOpenTDFControllerService.USE_PLAINTEXT)).thenReturn(usePlainText);
+
+        Mockito.when(clientID.getValue()).thenReturn(null);
+        Mockito.when(clientSecret.getValue()).thenReturn(null);
+        Mockito.when(platformEndpoint.getValue()).thenReturn(null);
+        Mockito.when(usePlainText.asBoolean()).thenReturn(null);
+
+        // Ensure that the enabled method throws an InitializationException
+        assertThrows(InitializationException.class, () -> service.enabled(context));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,25 @@
     </repositories>
     <profiles>
         <profile>
+            <id>develop</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.2.5</version>
+                        <configuration>
+                            <!--When using the maven-surefire-plugin or maven-failsafe-plugin you must not use a forkCount of 0 or set the forkMode to never as this would prevent the execution of the tests with the javaagent set and no coverage would be recorded.-->
+                            <forkCount>1</forkCount>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>stage</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -149,17 +149,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
-                    <configuration>
-                        <!--When using the maven-surefire-plugin or maven-failsafe-plugin you must not use a forkCount of 0 or set the forkMode to never as this would prevent the execution of the tests with the javaagent set and no coverage would be recorded.-->
-                        <forkCount>1</forkCount>
-                        <!-- this is required for test coverage-->
-<!--                        <argLine>${argLine}</argLine>-->
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                     <configuration>
@@ -339,6 +328,20 @@
                                 <goals>
                                     <goal>report-aggregate</goal>
                                 </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>${project.parent.basedir}/target/jacoco.exec</dataFile>
+                                    <outputDirectory>${project.parent.basedir}/target/site/jacoco/</outputDirectory>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -323,13 +323,6 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>report-aggregate</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>report-aggregate</goal>
-                                </goals>
-                            </execution>
-                            <execution>
                                 <id>report</id>
                                 <phase>test</phase>
                                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <junit.version>5.10.0</junit.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <jacoco.line.coverage>.7</jacoco.line.coverage>
     </properties>
     <modules>
@@ -153,6 +154,38 @@
 <!--                        <argLine>${argLine}</argLine>-->
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                    <configuration>
+                        <encoding>UTF-8</encoding>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                    <configuration>
+                        <encoding>UTF-8</encoding>
+                        <source>${maven.compiler.source}</source>
+                        <target>${maven.compiler.target}</target>
+                        <release>${maven.compiler.release}</release>
+                        <compilerArgs>
+                            <arg>-Xlint:unchecked</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -175,16 +208,6 @@
         <repository>
             <id>github</id>
             <url>https://maven.pkg.github.com/opentdf/nifi</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
-        <repository>
-            <id>opentdf</id>
-            <url>https://maven.pkg.github.com/opentdf/java-sdk</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>

--- a/settings.xml
+++ b/settings.xml
@@ -7,10 +7,5 @@
             <username>${env.GITHUB_ACTOR}</username>
             <password>${env.GITHUB_TOKEN}</password>
         </server>
-        <server>
-            <id>opentdf</id>
-            <username>${env.GITHUB_ACTOR}</username>
-            <password>${env.GITHUB_TOKEN}</password>
-        </server>
      </servers>
 </settings>


### PR DESCRIPTION
Modify test methods and assertions in ConvertToZTDFTest to use package-private visibility and improve assertion clarity. Enhance Javadocs for ConvertToZTDF, AbstractTDFProcessor, and related classes, including property descriptors and methods to improve code readability and maintainability.

DSP-154