### PR TITLE
ci:  GPG signing plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,26 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Plugin for Signing -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <repositories>
@@ -286,7 +306,7 @@
                             <autoPublish>true</autoPublish>
                             <waitUntil>published</waitUntil>
                             <!-- defined in settings.xml -->
-                            <publishingServerId>central</publishingServerId>
+                            <publishingServerId>github</publishingServerId>
                         </configuration>
                     </plugin>
                     <!-- Exclude from lifecycle, phase none -->


### PR DESCRIPTION
This commit introduces the maven-gpg-plugin to sign artifacts during the deploy phase, enhancing security and integrity. Additionally, the publishing server ID has been updated from 'central' to 'github' to adjust the deployment target.

DSP-154