### PR TITLE
fix: Add default constructors to processors and controller services

### DIFF
--- a/nifi-tdf-controller-services-api/pom.xml
+++ b/nifi-tdf-controller-services-api/pom.xml
@@ -11,6 +11,9 @@
     <name>nifi-tdf-controller-services-api</name>
     <description>TDF NiFi Controller Service API</description>
     <packaging>jar</packaging>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>

--- a/nifi-tdf-processors/pom.xml
+++ b/nifi-tdf-processors/pom.xml
@@ -118,6 +118,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.8.0</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>${maven.compiler.source}</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractTDFProcessor.java
@@ -29,6 +29,13 @@ import java.util.*;
 public abstract class AbstractTDFProcessor extends AbstractProcessor {
 
     /**
+     * Default constructor for AbstractTDFProcessor.
+     */
+    public AbstractTDFProcessor() {
+        super();
+    }
+
+    /**
      * Configuration property representing the limit on the number of FlowFiles
      * that can be pulled from the FlowFile queue at a time.
      * It supports expression language through the variable registry and has a default value of 10.

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractToProcessor.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/AbstractToProcessor.java
@@ -21,6 +21,16 @@ public abstract class AbstractToProcessor extends AbstractTDFProcessor{
     static final String TDF_ATTRIBUTE = "tdf_attribute";
     static final String TDF_ASSERTION_PREFIX = "tdf_assertion_";
 
+    /**
+     * Default constructor for AbstractToProcessor.
+     */
+    public AbstractToProcessor() {
+        super();
+    }
+
+    /**
+     * Property descriptor for the Key Access Server (KAS) URL configuration.
+     */
     public static final PropertyDescriptor KAS_URL = new org.apache.nifi.components.PropertyDescriptor.Builder()
             .name("KAS URL")
             .expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromNanoTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromNanoTDF.java
@@ -25,6 +25,13 @@ import java.util.List;
 public class ConvertFromNanoTDF extends AbstractTDFProcessor {
 
     /**
+     * Default constructor for ConvertFromNanoTDF.
+     */
+    public ConvertFromNanoTDF() {
+        super();
+    }
+
+    /**
      * Processes the provided list of flow files by decrypting their content using the NanoTDF protocol.
      * If decryption succeeds, the flow file is routed to the success relationship; otherwise, it is routed to the failure relationship.
      *

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -41,6 +41,12 @@ import java.util.List;
 @Tags({"ZTDF", "Zero Trust Data Format", "OpenTDF", "Decrypt", "Data Centric Security"})
 public class ConvertFromZTDF extends AbstractTDFProcessor {
 
+    /**
+     * Default constructor for ConvertFromZTDF.
+     */
+    public ConvertFromZTDF() {
+        super();
+    }
 
     /**
      * Processes a list of flow files by decrypting their content using the TDF (Trusted Data Format) SDK.

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToNanoTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToNanoTDF.java
@@ -50,6 +50,13 @@ import java.util.Set;
 public class ConvertToNanoTDF extends AbstractToProcessor {
 
     /**
+     * Default constructor for ConvertToNanoTDF.
+     */
+    public ConvertToNanoTDF() {
+        super();
+    }
+
+    /**
      * Defines a relationship indicating that NanoTDF creation has failed
      * due to the content size exceeding the maximum allowed NanoTDF size threshold.
      */

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -53,6 +53,13 @@ import java.util.function.Consumer;
 public class ConvertToZTDF extends AbstractToProcessor {
 
     /**
+     * Default constructor for ConvertToZTDF.
+     */
+    public ConvertToZTDF() {
+        super();
+    }
+
+    /**
      * Property descriptor for the "Sign Assertions" feature in the ConvertToZTDF processor. This property allows specifying whether 
      * the assertions should be signed or not. It is not a required property and defaults to "false".
      * <p>

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/SimpleOpenTDFControllerService.java
@@ -23,6 +23,13 @@ import java.util.List;
 public class SimpleOpenTDFControllerService extends AbstractControllerService implements OpenTDFControllerService {
 
     /**
+     * Default constructor for SimpleOpenTDFControllerService.
+     */
+    public SimpleOpenTDFControllerService() {
+        super();
+    }
+
+    /**
      * The endpoint of the OpenTDF platform in GRPC compatible format, excluding the protocol prefix.
      * This is a required property and supports expression language within the scope of the variable registry.
      */

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.3</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.2.3</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
This commit adds default constructors to several processors and controller services to ensure they're properly initialized. 

It also introduces build-source encoding in the POM files and adds the maven-gpg-plugin version.