### PR TITLE
chore: Update repository and publishing server IDs in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
                         <artifactId>maven-deploy-plugin</artifactId>
                         <version>3.1.2</version>
                         <configuration>
-                            <repositoryId>github-pkg</repositoryId>
+                            <repositoryId>github</repositoryId>
                             <url>https://maven.pkg.github.com/opentdf/nifi</url>
                         </configuration>
                     </plugin>
@@ -311,7 +311,7 @@
                             <autoPublish>true</autoPublish>
                             <waitUntil>published</waitUntil>
                             <!-- defined in settings.xml -->
-                            <publishingServerId>github</publishingServerId>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                     <!-- Exclude from lifecycle, phase none -->


### PR DESCRIPTION
Corrected the repositoryId and publishingServerId in the maven-deploy plugin configuration to ensure proper deployment. Changed 'github-pkg' to 'github' and 'github' to 'central'.