### PR TITLE
fix: Update OpenTDF SDK dependency version to 0.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>io.opentdf.platform</groupId>
                 <artifactId>sdk</artifactId>
-                <version>0.7.3</version>
+                <version>0.7.5</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgraded the SDK version from 0.7.3 to 0.7.5 in the `pom.xml` file. This update is necessary for compatibility with new features and bug fixes provided in the latest SDK release.

https://github.com/opentdf/java-sdk/releases/tag/v0.7.5
https://github.com/opentdf/java-sdk/releases/tag/v0.7.4