### PR TITLE
ci: Add security to CODEOWNERS for reviewing dependency updates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,10 @@
 
 * @opentdf/opentdf-nifi @opentdf/architecture
 
+## General
+
+*pom.xml       @opentdf/architecture @opentdf/security
+
 ## High Security Area
 
 CODEOWNERS     @opentdf/architecture @opentdf/security


### PR DESCRIPTION
This PR adds security to CODEOWNERS for reviewing the `pom.xml`.  This is so we can assist in needed security updates, for example:
* https://github.com/opentdf/nifi/security/dependabot/5
* https://github.com/opentdf/nifi/security/dependabot/6