### PR TITLE
fix(sdk): update opentdf java sdk to 0.7.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /.idea/
 /**/target/
+/nifi-rel-nifi-*/
+Dockerfile*
+nifi-**.tar.gz 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
+NIFI_VERSION?=1.28.1
+
+nifi-image:
+	wget https://raw.githubusercontent.com/apache/nifi/refs/tags/rel/nifi-$(NIFI_VERSION)/nifi-docker/dockerhub/Dockerfile
+	curl -L https://github.com/apache/nifi/archive/refs/tags/rel/nifi-$(NIFI_VERSION).tar.gz -o nifi-$(NIFI_VERSION).tar.gz
+	tar -xzf nifi-$(NIFI_VERSION).tar.gz
+	docker build -t opentdf-nifi:local -f ./nifi-rel-nifi-$(NIFI_VERSION)/nifi-docker/dockerhub/Dockerfile --build-arg IMAGE_TAG=17-jre --build-arg BASE_URL=https://dlcdn.apache.org --build-arg NIFI_VERSION=$(NIFI_VERSION) --build-arg IMAGE_NAME=public.ecr.aws/docker/library/eclipse-temurin ./nifi-rel-nifi-$(NIFI_VERSION)/nifi-docker/dockerhub
+
 
 .PHONY: compose-package
 compose-package: nar-build
 	@echo "package for docker compose"
+	mkdir -p deploy/extensions
 	rm -rf deploy/extensions/*.nar
 	cp nifi-tdf-nar/target/*.nar deploy/extensions
 	cp nifi-tdf-controller-services-api-nar/target/*.nar deploy/extensions

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Upload and use this template in NiFi:
     export GITHUB_TOKEN=your gh token
     make compose-package
     ```
+1. Build local Nifi Image
+
+    ```shell
+    make nifi-image
+    ```
+
 1. Start docker compose
     ```shell
     docker compose up

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   opentdf-nifi:
-    image: ghcr.io/ttschampel/nifi/nifi-1.25.0-jre17:latest
+    image: opentdf-nifi:local
     restart: always
     ulimits:
       nofile:

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -1,8 +1,10 @@
 package io.opentdf.nifi;
 
 import io.opentdf.platform.sdk.Config;
+import io.opentdf.platform.sdk.Config.TDFConfig;
 import io.opentdf.platform.sdk.SDK;
 import io.opentdf.platform.sdk.TDF;
+import io.opentdf.platform.sdk.KeyType;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.apache.nifi.annotation.documentation.CapabilityDescription;
 import org.apache.nifi.annotation.documentation.Tags;
@@ -65,14 +67,13 @@ public class ConvertFromZTDF extends AbstractTDFProcessor {
     @Override
     void processFlowFiles(ProcessContext processContext, ProcessSession processSession, List<FlowFile> flowFiles) throws ProcessException {
         SDK sdk = getTDFSDK(processContext);
-        //TODO add assertion verification key list population
-        List<Config.AssertionVerificationKeys> assertionVerificationKeysList = new ArrayList<>();
+        
         for (FlowFile flowFile : flowFiles) {
             try {
                 try (SeekableByteChannel seekableByteChannel = new SeekableInMemoryByteChannel(readEntireFlowFile(flowFile, processSession))) {
                     FlowFile updatedFlowFile = processSession.write(flowFile, outputStream -> {
                         try {
-                            TDF.Reader reader = getTDF().loadTDF(seekableByteChannel, sdk.getServices().kas(), assertionVerificationKeysList.toArray(new Config.AssertionVerificationKeys[0]));
+                            TDF.Reader reader = getTDF().loadTDF(seekableByteChannel, sdk.getServices().kas(), Config.newTDFReaderConfig(Config.withDisableAssertionVerification(true)), sdk.getServices().kasRegistry(), sdk.getPlatformUrl());
                             reader.readPayload(outputStream);
                         } catch (Exception e) {
                             getLogger().error("error decrypting ZTDF", e);

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertFromZTDF.java
@@ -75,6 +75,9 @@ public class ConvertFromZTDF extends AbstractTDFProcessor {
                         try {
                             TDF.Reader reader = getTDF().loadTDF(seekableByteChannel, sdk.getServices().kas(), Config.newTDFReaderConfig(Config.withDisableAssertionVerification(true)), sdk.getServices().kasRegistry(), sdk.getPlatformUrl());
                             reader.readPayload(outputStream);
+                        } catch (InterruptedException e) {
+                            getLogger().error("error decrypting ZTDF", e);
+                            Thread.currentThread().interrupt();
                         } catch (Exception e) {
                             getLogger().error("error decrypting ZTDF", e);
                             throw new IOException(e);

--- a/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
+++ b/nifi-tdf-processors/src/main/java/io/opentdf/nifi/ConvertToZTDF.java
@@ -255,7 +255,7 @@ public class ConvertToZTDF extends AbstractToProcessor {
                 getLogger().debug("adding signing configuration for assertion");
                 //TODO assumes RSA256 signing key
                 PrivateKey privateKey = privateKeyService.getPrivateKey();
-                assertionConfig.assertionKey = new AssertionConfig.AssertionKey(AssertionConfig.AssertionKeyAlg.RS256, privateKey);
+                assertionConfig.signingKey = new AssertionConfig.AssertionKey(AssertionConfig.AssertionKeyAlg.RS256, privateKey);
             }
         }
     }

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
@@ -133,8 +133,8 @@ class ConvertToZTDFTest {
         assertEquals(1, assertionConfigList.size());
         AssertionConfig assertionConfig = assertionConfigList.get(0);
         assertNotNull(assertionConfig, "Assertion configuration present");
-        assertNotNull(assertionConfig.assertionKey.key, "signing key present");
-        assertEquals(AssertionConfig.AssertionKeyAlg.RS256, assertionConfig.assertionKey.alg);
+        assertNotNull(assertionConfig.signingKey.key, "signing key present");
+        assertEquals(AssertionConfig.AssertionKeyAlg.RS256, assertionConfig.signingKey.alg);
         assertEquals("a test assertion", assertionConfig.statement.value);
         assertEquals("sample", assertionConfig.statement.format);
         assertEquals(AssertionConfig.Scope.Payload, assertionConfig.scope);

--- a/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
+++ b/nifi-tdf-processors/src/test/java/io/opentdf/nifi/ConvertToZTDFTest.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.JOSEException;
 import io.opentdf.platform.policy.attributes.AttributesServiceGrpc;
 import io.opentdf.platform.sdk.*;
 import io.opentdf.platform.sdk.Config;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.io.IOUtils;
 import org.apache.nifi.key.service.api.PrivateKeyService;
 import org.apache.nifi.processor.ProcessContext;
@@ -146,7 +147,7 @@ class ConvertToZTDFTest {
         assertEquals(1, flowFileList.size(), "one success flow file");
     }
 
-    private Captures commonProcessorTestSetup(TestRunner runner) throws IOException, JOSEException, ExecutionException, InterruptedException {
+    private Captures commonProcessorTestSetup(TestRunner runner) throws IOException, JOSEException, ExecutionException, InterruptedException, DecoderException {
         ((ConvertToZTDFTest.MockRunner) runner.getProcessor()).mockSDK = mockSDK;
         ((ConvertToZTDFTest.MockRunner) runner.getProcessor()).mockTDF = mockTDF;
         runner.setProperty(ConvertToZTDF.KAS_URL, "https://kas1");

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             <dependency>
                 <groupId>io.opentdf.platform</groupId>
                 <artifactId>sdk</artifactId>
-                <version>0.7.3</version>
+                <version>0.7.9</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
addresses https://github.com/opentdf/nifi/issues/47 by updating the opentdf java sdk version to the latest, 0.7.9. updates the ztdf conversion classes to use update config signatures.

~~I am having issues getting the tests to pass however~~ Thanks to Tim for help with this!